### PR TITLE
Relative config paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## About
 
-PyARINC424 is a tool that parses an [ARINC-424](https://en.wikipedia.org/wiki/ARINC_424) formatted data file into a PostreSQL database. PyARINC424 supports the tables/records that are currently output in [FAA CIFP](https://www.faa.gov/air_traffic/flight_info/aeronav/digital_products/cifp/download/):
+PyARINC424 is a tool that parses an [ARINC-424](https://en.wikipedia.org/wiki/ARINC_424) formatted data file into a SQLite or PostreSQL database. PyARINC424 supports the tables/records that are currently output in [FAA CIFP](https://www.faa.gov/air_traffic/flight_info/aeronav/digital_products/cifp/download/):
 - Airports and heliports (PA and HA)
 - Runways (PG)
 - VHF Navaids (D)

--- a/src/pyarinc424/config.py
+++ b/src/pyarinc424/config.py
@@ -1,4 +1,5 @@
 import configparser
+import os
 
 
 class UserConfigs:
@@ -24,6 +25,12 @@ class UserConfigs:
             self.dbname = parser["sqlite"]["dbname"]
 
         self.file_loc = parser["cifp_file"]["file_loc"]
+
+        # if the file_loc path is not absolute, make it absolute and relative to the config file
+        if not self.file_loc.startswith("/"):
+            self.file_loc = os.path.abspath(
+                os.path.join(os.path.dirname(config_file), self.file_loc)
+            )
 
 
 def validate(parser: configparser.ConfigParser) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest import mock
 import configparser
+import os
 from pyarinc424.config import UserConfigs, validate  # type: ignore
 
 
@@ -185,3 +186,27 @@ class TestUserConfigs:
             FileNotFoundError, match="Configuration file missing.ini not found"
         ):
             UserConfigs("missing.ini")
+
+
+class TestUserConfigsRelativeFileLoc:
+    def test_relative_file_loc_conversion(self, tmp_path):
+        """Test that a relative file_loc in the configuration is converted to an absolute path."""
+        config_content = """
+            [postgres]
+            dbname = testdb
+            user = testuser
+            password = testpass
+            host = localhost
+            port = 5432
+
+            [cifp_file]
+            file_loc = relative/path/to/file
+        """
+        config_file = tmp_path / "config.ini"
+        config_file.write_text(config_content.strip())
+
+        user_configs = UserConfigs(str(config_file))
+        expected_path = os.path.abspath(
+            os.path.join(os.path.dirname(str(config_file)), "relative/path/to/file")
+        )
+        assert user_configs.file_loc == expected_path


### PR DESCRIPTION
The previous behavior when handling a relative file path for the config `file_loc` was confusing. This change makes the program treat a relative `file_loc` path as relative to the config file, which is more intuitive. 